### PR TITLE
Make returns consistent

### DIFF
--- a/contracts/solidity/MultiSigWallet.sol
+++ b/contracts/solidity/MultiSigWallet.sol
@@ -164,10 +164,11 @@ contract MultiSigWallet {
     /// @return transactionHash Returns hash identifying a transaction.
     function submitTransaction(address destination, uint value, bytes data, uint nonce)
         public
-        returns (bytes32 transactionHash)
+        returns (bytes32)
     {
-        transactionHash = addTransaction(destination, value, data, nonce);
+        bytes32 transactionHash = addTransaction(destination, value, data, nonce);
         confirmTransaction(transactionHash);
+        return transactionHash;
     }
 
     /// @dev Allows an owner to confirm a transaction.

--- a/contracts/solidity/MultiSigWallet.sol
+++ b/contracts/solidity/MultiSigWallet.sol
@@ -245,11 +245,13 @@ contract MultiSigWallet {
     function confirmationCount(bytes32 transactionHash)
         public
         constant
-        returns (uint count)
+        returns (uint)
     {
+        uint count = 0;
         for (uint i=0; i<owners.length; i++)
             if (confirmations[transactionHash][owners[i]])
                 count += 1;
+        return count;
     }
 
     /*
@@ -304,20 +306,22 @@ contract MultiSigWallet {
     function filterTransactions(bool isPending)
         public
         constant
-        returns (bytes32[] _transactionList)
+        returns (bytes32[])
     {
         bytes32[] memory transactionListTemp = new bytes32[](transactionList.length);
         uint count = 0;
-        for (uint i=0; i<transactionList.length; i++)
+        for (uint i=0; i<transactionList.length; i++) {
             if (   isPending && !transactions[transactionList[i]].executed
                 || !isPending && transactions[transactionList[i]].executed)
             {
                 transactionListTemp[count] = transactionList[i];
                 count += 1;
             }
-        _transactionList = new bytes32[](count);
+        }
+        bytes32[] memory _transactionList = new bytes32[](count);
         for (i=0; i<count; i++)
             _transactionList[i] = transactionListTemp[i];
+        return _transactionList;
     }
 
     /// @dev Returns transaction hashes of pending transactions.

--- a/contracts/solidity/MultiSigWallet.sol
+++ b/contracts/solidity/MultiSigWallet.sol
@@ -214,7 +214,7 @@ contract MultiSigWallet {
     function isConfirmed(bytes32 transactionHash)
         public
         constant
-        returns (bool confirmed)
+        returns (bool)
     {
         uint count = 0;
         for (uint i=0; i<owners.length; i++) {
@@ -223,6 +223,7 @@ contract MultiSigWallet {
             if (count == required)
                 return true;
         }
+        return false;
     }
 
     /// @dev Returns the nonce for a new transaction.
@@ -233,7 +234,7 @@ contract MultiSigWallet {
     function getNonce(address destination, uint value, bytes data)
         public
         constant
-        returns (uint nonce)
+        returns (uint)
     {
         return nonces[keccak256(destination, value, data)];
     }
@@ -264,9 +265,9 @@ contract MultiSigWallet {
         internal
         notNull(destination)
         validNonce(destination, value, data, nonce)
-        returns (bytes32 transactionHash)
+        returns (bytes32)
     {
-        transactionHash = keccak256(destination, value, data, nonce);
+        bytes32 transactionHash = keccak256(destination, value, data, nonce);
         if (transactions[transactionHash].destination == 0) {
             transactions[transactionHash] = Transaction({
                 destination: destination,
@@ -279,6 +280,7 @@ contract MultiSigWallet {
             transactionList.push(transactionHash);
             Submission(transactionHash);
         }
+        return transactionHash;
     }
 
     /// @dev Adds a confirmation from an owner for a transaction.
@@ -323,7 +325,7 @@ contract MultiSigWallet {
     function getPendingTransactions()
         public
         constant
-        returns (bytes32[] _transactionList)
+        returns (bytes32[])
     {
         return filterTransactions(true);
     }
@@ -333,7 +335,7 @@ contract MultiSigWallet {
     function getExecutedTransactions()
         public
         constant
-        returns (bytes32[] _transactionList)
+        returns (bytes32[])
     {
         return filterTransactions(false);
     }


### PR DESCRIPTION
For safety and clarity, prefer explicit returns. And remove unused named returns.