### PR TITLE
Added modifier ownerExists to submitTransaction

### DIFF
--- a/contracts/solidity/MultiSigWallet.sol
+++ b/contracts/solidity/MultiSigWallet.sol
@@ -168,6 +168,7 @@ contract MultiSigWallet {
     /// @return Returns hash identifying a transaction.
     function submitTransaction(address destination, uint value, bytes data, uint nonce)
         public
+        ownerExists(msg.sender)
         returns (bytes32 transactionHash)
     {
         transactionHash = addTransaction(destination, value, data, nonce);


### PR DESCRIPTION
submitTransaction calls confirmTransaction, which has the same modifier, but why let non-owners in if they'll get kicked out eventually anyways?