### PR TITLE
Unwanted decrement of the required confirmations

### DIFF
--- a/contracts/solidity/MultiSigWallet.sol
+++ b/contracts/solidity/MultiSigWallet.sol
@@ -164,8 +164,8 @@ contract MultiSigWallet {
             }
         isOwner[owner] = false;
         isOwner[newOwner] = true;
-        OwnerRemoval(owner);
         OwnerAddition(newOwner);
+        OwnerRemoval(owner);
     }
 
     /// @dev Allows to change the number of required confirmations. Transaction has to be sent by wallet.


### PR DESCRIPTION
In the replaceOwner function, when you call OwnerRemoval before OwnerAddition, you can launch a changeRequirement that decrease the required confirmations number.
To avoid this, it's better to add the new owner before removing the old one.

There is however a small side effect: it will no longer be possible to call replaceOwner if the MAX_OWNER_COUNT is reached.